### PR TITLE
Run GitHub Actions tests on `v1` branch

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - v1
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
We're continuing development on the new `v1` branch instead of `master` or `main`.