### PR TITLE
Allow API endpoints to determine default boolean option values

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -38,7 +38,7 @@ type Filter struct {
 
 // GetMyFiltersQueryOptions specifies the optional parameters for the Get My Filters method
 type GetMyFiltersQueryOptions struct {
-	IncludeFavourites bool   `url:"includeFavourites,omitempty"`
+	IncludeFavourites *bool  `url:"includeFavourites,omitempty"`
 	Expand            string `url:"expand,omitempty"`
 }
 

--- a/issue.go
+++ b/issue.go
@@ -34,9 +34,9 @@ type IssueService struct {
 
 // UpdateQueryOptions specifies the optional parameters to the Edit issue
 type UpdateQueryOptions struct {
-	NotifyUsers            bool `url:"notifyUsers,omitempty"`
-	OverrideScreenSecurity bool `url:"overrideScreenSecurity,omitempty"`
-	OverrideEditableFlag   bool `url:"overrideEditableFlag,omitempty"`
+	NotifyUsers            *bool `url:"notifyUsers,omitempty"`
+	OverrideScreenSecurity *bool  `url:"overrideScreenSecurity,omitempty"`
+	OverrideEditableFlag   *bool  `url:"overrideEditableFlag,omitempty"`
 }
 
 // Issue represents a Jira issue.
@@ -544,8 +544,8 @@ type GetQueryOptions struct {
 	// Properties is the list of properties to return for the issue. By default no properties are returned.
 	Properties string `url:"properties,omitempty"`
 	// FieldsByKeys if true then fields in issues will be referenced by keys instead of ids
-	FieldsByKeys  bool   `url:"fieldsByKeys,omitempty"`
-	UpdateHistory bool   `url:"updateHistory,omitempty"`
+	FieldsByKeys  *bool  `url:"fieldsByKeys,omitempty"`
+	UpdateHistory *bool  `url:"updateHistory,omitempty"`
 	ProjectKeys   string `url:"projectKeys,omitempty"`
 }
 
@@ -558,12 +558,12 @@ type GetWorklogsQueryOptions struct {
 }
 
 type AddWorklogQueryOptions struct {
-	NotifyUsers          bool   `url:"notifyUsers,omitempty"`
+	NotifyUsers          *bool  `url:"notifyUsers,omitempty"`
 	AdjustEstimate       string `url:"adjustEstimate,omitempty"`
 	NewEstimate          string `url:"newEstimate,omitempty"`
 	ReduceBy             string `url:"reduceBy,omitempty"`
 	Expand               string `url:"expand,omitempty"`
-	OverrideEditableFlag bool   `url:"overrideEditableFlag,omitempty"`
+	OverrideEditableFlag *bool  `url:"overrideEditableFlag,omitempty"`
 }
 
 // CustomFields represents custom fields of Jira


### PR DESCRIPTION
On Jira API endpoints that accept boolean parameters, the value of the parameter may default to either true or false if it isn't supplied in the request, depending on the endpoint. In options structs that have them, change the type of fields representing these parameters from `bool` to `*bool`, so that their value isn't explicitly set to false in the request if a value isn't given in the struct - in order words, let the API endpoint decide what the value should be, not go-jira.