### PR TITLE
IssueService: add `WithOptions` function variants for `UpdateIssue`

### DIFF
--- a/issue_test.go
+++ b/issue_test.go
@@ -154,6 +154,29 @@ func TestIssueService_Update(t *testing.T) {
 	}
 }
 
+func TestIssueService_UpdateIssueWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+	testMux.HandleFunc("/rest/api/2/issue/PROJ-9001", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testRequestURL(t, r, "/rest/api/2/issue/PROJ-9001?notifyUsers=false")
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+	jID := "PROJ-9001"
+	i := make(map[string]interface{})
+	fields := make(map[string]interface{})
+	i["fields"] = fields
+	opts := &UpdateQueryOptions{NotifyUsers: Bool(false)}
+	resp, err := testClient.Issue.UpdateIssueWithOptions(jID, i, opts)
+	if resp == nil {
+		t.Error("Expected resp. resp is nil")
+	}
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+}
+
 func TestIssueService_UpdateIssue(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This enables options to be set for the "edit issue" API endpoint via query parameters in the `UpdateIssue` family of functions, similarly to how it currently works for the `Update` family of functions.