### PR TITLE
feat(issue): add statuscategorychangedate to fields

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -46,15 +46,15 @@ type BulkRequest struct {
 
 // BulkResult represents the specific JSON body returned by the Bulk API.
 type BulkResult struct {
-	Issues []Issue `json:"issues"`
+	Issues []Issue     `json:"issues"`
 	Errors []BulkError `json:"errors"`
 }
 
 // BulkError represents the error structure specific to bulk operations.
 type BulkError struct {
-	Status int `json:"status"`
+	Status        int               `json:"status"`
 	ElementErrors map[string]string `json:"elementErrors"`
-	FailedElement int `json:"failedElementNumber"`
+	FailedElement int               `json:"failedElementNumber"`
 }
 
 // Issue represents a Jira issue.
@@ -151,6 +151,7 @@ type IssueFields struct {
 	Worklog                       *Worklog          `json:"worklog,omitempty" structs:"worklog,omitempty"`
 	IssueLinks                    []*IssueLink      `json:"issuelinks,omitempty" structs:"issuelinks,omitempty"`
 	Comments                      *Comments         `json:"comment,omitempty" structs:"comment,omitempty"`
+	StatusCategoryChangeDate      Time              `json:"statuscategorychangedate,omitempty" structs:"statuscategorychangedate,omitempty"`
 	FixVersions                   []*FixVersion     `json:"fixVersions,omitempty" structs:"fixVersions,omitempty"`
 	AffectsVersions               []*AffectsVersion `json:"versions,omitempty" structs:"versions,omitempty"`
 	Labels                        []string          `json:"labels,omitempty" structs:"labels,omitempty"`
@@ -1508,19 +1509,17 @@ func (s *IssueService) DoTransitionWithPayload(ticketID, payload interface{}) (*
 
 // InitIssueWithMetaAndFields returns Issue with with values from fieldsConfig properly set.
 //   - metaProject should contain metaInformation about the project where the issue should be created.
-//  --  metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
-//  --   fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
-//  --   And value is the string value for that particular key.
-//   -  
-//     
+//     --  metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
+//     --   fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
+//     --   And value is the string value for that particular key.
+//     -
 //
 // Note: This method doesn't verify that the fieldsConfig is complete with mandatory fields. The fieldsConfig is
 //
+// posed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
+// rr if the key is not found.
+// Al values will be packed into Unknowns. This is much convenient. If the struct fields needs to be
 //
-//
-//posed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
-//rr if the key is not found.
-//Al values will be packed into Unknowns. This is much convenient. If the struct fields needs to be
 //	configured as well, marshalling and unmarshalling will set the proper fields.
 func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIssueType, fieldsConfig map[string]string) (*Issue, error) {
 	issue := new(Issue)

--- a/issue_test.go
+++ b/issue_test.go
@@ -1924,7 +1924,7 @@ func TestIssueService_Get_StatusCategoryChangeDate(t *testing.T) {
 		t.Error("Expected StatusCategoryChangeDate to be set, but it was zero")
 	}
 
-	// Jira usually sends this format: "2006-01-02T15:04:05.000-0700"
+	// We expect Jira to send this format: "2006-01-02T15:04:05.000-0700"
 	expectedTime, err := time.Parse("2006-01-02T15:04:05.000-0700", timeStr)
 	if err != nil {
 		t.Errorf("Bad test setup time format: %s", err)

--- a/issue_test.go
+++ b/issue_test.go
@@ -1886,6 +1886,57 @@ func TestIssueService_Get_Transitions(t *testing.T) {
 	}
 }
 
+func TestIssueService_Get_StatusCategoryChangeDate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	// Define the expected timestamp string
+	timeStr := "2024-02-14T10:00:00.000+0000"
+
+	testMux.HandleFunc("/rest/api/2/issue/10002", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, "/rest/api/2/issue/10002")
+
+		// Mimic the Jira response structure
+		fmt.Fprintf(w, `{
+			"expand":"renderedFields,names,schema,transitions,operations,editmeta,changelog,versionedRepresentations",
+			"id":"10002",
+			"self":"http://www.example.com/jira/rest/api/2/issue/10002",
+			"key":"EX-1",
+			"fields":{
+				"summary": "Test Issue",
+				"statuscategorychangedate": "%s"
+			}
+		}`, timeStr)
+	})
+
+	issue, _, err := testClient.Issue.Get("10002", nil)
+	if err != nil {
+		t.Errorf("Error given: %s", err)
+	}
+	if issue == nil {
+		t.Error("Expected issue. Issue is nil")
+		return
+	}
+
+	// Verify the field was populated
+	if time.Time(issue.Fields.StatusCategoryChangeDate).IsZero() {
+		t.Error("Expected StatusCategoryChangeDate to be set, but it was zero")
+	}
+
+	// Jira usually sends this format: "2006-01-02T15:04:05.000-0700"
+	expectedTime, err := time.Parse("2006-01-02T15:04:05.000-0700", timeStr)
+	if err != nil {
+		t.Errorf("Bad test setup time format: %s", err)
+	}
+
+	actualTime := time.Time(issue.Fields.StatusCategoryChangeDate)
+
+	if !actualTime.Equal(expectedTime) {
+		t.Errorf("Expected time %v, but got %v", expectedTime, actualTime)
+	}
+}
+
 func TestIssueService_Get_Fields_AffectsVersions(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This is an available field in the issue object so support returning it. Annoyingly, JQL surfaces this field as `statusCategoryChangedDate` (`changed` rather than `change`) but the API is consistent with its use of `change` so stick with this in the struct name.

Other changes have been applied by lint.