### PR TITLE
feat(issue): support returnIssue query parameter in edit issue

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -37,6 +37,7 @@ type UpdateQueryOptions struct {
 	NotifyUsers            *bool `url:"notifyUsers,omitempty"`
 	OverrideScreenSecurity *bool `url:"overrideScreenSecurity,omitempty"`
 	OverrideEditableFlag   *bool `url:"overrideEditableFlag,omitempty"`
+	ReturnIssue            *bool `url:"returnIssue,omitempty"`
 }
 
 // BulkRequest represents a series of Jira issues.
@@ -984,6 +985,16 @@ func (s *IssueService) UpdateWithOptionsWithContext(ctx context.Context, issue *
 	req, err := s.client.NewRequestWithContext(ctx, "PUT", url, issue)
 	if err != nil {
 		return nil, nil, err
+	}
+	// Branch if we have requested to return the new issue.
+	if opts != nil && opts.ReturnIssue != nil && *opts.ReturnIssue {
+		responseIssue := new(Issue)
+		resp, err := s.client.Do(req, responseIssue)
+		if err != nil {
+			jerr := NewJiraError(resp, err)
+			return nil, resp, jerr
+		}
+		return responseIssue, resp, nil
 	}
 	resp, err := s.client.Do(req, nil)
 	if err != nil {

--- a/issue_test.go
+++ b/issue_test.go
@@ -292,6 +292,48 @@ func TestIssueService_UpdateIssueWithOptions(t *testing.T) {
 	}
 }
 
+func TestIssueService_UpdateWithOptions_ReturnIssue(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/rest/api/2/issue/TEST-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testRequestURL(t, r, "/rest/api/2/issue/TEST-1?returnIssue=true")
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"key":"TEST-1", "fields":{"summary":"Updated Summary via ReturnIssue"}}`)
+	})
+
+	issue := &Issue{
+		Key: "TEST-1",
+		Fields: &IssueFields{
+			Summary: "Updated Summary via ReturnIssue",
+		},
+	}
+
+	shouldReturn := true
+	opts := &UpdateQueryOptions{
+		ReturnIssue: &shouldReturn,
+	}
+
+	updatedIssue, resp, err := testClient.Issue.UpdateWithOptions(issue, opts)
+	if err != nil {
+		t.Errorf("Issue.UpdateWithOptions returned error: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+
+	if updatedIssue == nil {
+		t.Fatal("Expected updatedIssue to be non-nil")
+	}
+
+	if updatedIssue.Fields.Summary != "Updated Summary via ReturnIssue" {
+		t.Errorf("Expected summary 'Updated Summary via ReturnIssue', got '%s'", updatedIssue.Fields.Summary)
+	}
+}
+
 func TestIssueService_UpdateIssue(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
The edit issue API supports a `returnIssue` query parameter: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-put

Add support for this parameter.