### PR TITLE
feat(issue): add edit methods for issue key that returns new issue

### DIFF
--- a/issue.go
+++ b/issue.go
@@ -1070,6 +1070,59 @@ func (s *IssueService) UpdateIssue(jiraID string, data map[string]interface{}) (
 	return s.UpdateIssueWithContext(context.Background(), jiraID, data)
 }
 
+// UpdateIssueAndReturnWithOptionsWithContext updates an issue from a map,
+// forces the returnIssue=true parameter, and returns the updated Issue.
+//
+// Jira API docs: https://docs.atlassian.com/jira/REST/cloud/#api/2/issue-editIssue
+// Caller must close resp.Body
+func (s *IssueService) UpdateIssueAndReturnWithOptionsWithContext(ctx context.Context, jiraID string, data map[string]interface{}, opts *UpdateQueryOptions) (*Issue, *Response, error) {
+	apiEndpoint := fmt.Sprintf("rest/api/2/issue/%v", jiraID)
+
+	var localOpts UpdateQueryOptions
+	if opts != nil {
+		localOpts = *opts
+	}
+	shouldReturn := true
+	localOpts.ReturnIssue = &shouldReturn
+
+	url, err := addOptions(apiEndpoint, &localOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.client.NewRequestWithContext(ctx, "PUT", url, data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	responseIssue := new(Issue)
+	resp, err := s.client.Do(req, responseIssue)
+	if err != nil {
+		jerr := NewJiraError(resp, err)
+		return nil, resp, jerr
+	}
+
+	return responseIssue, resp, nil
+}
+
+// UpdateIssueAndReturnWithOptions wraps UpdateIssueAndReturnWithOptionsWithContext using the background context.
+// Caller must close resp.Body
+func (s *IssueService) UpdateIssueAndReturnWithOptions(jiraID string, data map[string]interface{}, opts *UpdateQueryOptions) (*Issue, *Response, error) {
+	return s.UpdateIssueAndReturnWithOptionsWithContext(context.Background(), jiraID, data, opts)
+}
+
+// UpdateIssueAndReturnWithContext updates an issue from a map and returns the updated issue.
+// Caller must close resp.Body
+func (s *IssueService) UpdateIssueAndReturnWithContext(ctx context.Context, jiraID string, data map[string]interface{}) (*Issue, *Response, error) {
+	return s.UpdateIssueAndReturnWithOptionsWithContext(ctx, jiraID, data, nil)
+}
+
+// UpdateIssueAndReturn wraps UpdateIssueAndReturnWithContext using the background context.
+// Caller must close resp.Body
+func (s *IssueService) UpdateIssueAndReturn(jiraID string, data map[string]interface{}) (*Issue, *Response, error) {
+	return s.UpdateIssueAndReturnWithContext(context.Background(), jiraID, data)
+}
+
 // AddCommentWithContext adds a new comment to issueID.
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-addComment

--- a/issue_test.go
+++ b/issue_test.go
@@ -357,6 +357,61 @@ func TestIssueService_UpdateIssue(t *testing.T) {
 
 }
 
+func TestIssueService_UpdateIssueAndReturnWithOptions(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testMux.HandleFunc("/rest/api/2/issue/TEST-1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testRequestURL(t, r, "/rest/api/2/issue/TEST-1?notifyUsers=false&returnIssue=true")
+
+		j := new(map[string]interface{})
+		err := json.NewDecoder(r.Body).Decode(j)
+		if err != nil {
+			t.Errorf("Couldn't decode request body: %v", err)
+		}
+
+		fields, ok := (*j)["fields"].(map[string]interface{})
+		if !ok {
+			t.Errorf("Expected 'fields' in request body")
+		}
+		if fields["summary"] != "New Map Summary" {
+			t.Errorf("Expected summary 'New Map Summary', got '%s'", fields["summary"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"key":"TEST-1", "fields":{"summary":"New Map Summary"}}`)
+	})
+
+	updateData := map[string]interface{}{
+		"fields": map[string]interface{}{
+			"summary": "New Map Summary",
+		},
+	}
+
+	opts := &UpdateQueryOptions{
+		NotifyUsers: Bool(false),
+	}
+
+	updatedIssue, resp, err := testClient.Issue.UpdateIssueAndReturnWithOptions("TEST-1", updateData, opts)
+
+	if err != nil {
+		t.Errorf("Issue.UpdateIssueAndReturnWithOptions returned error: %v", err)
+	}
+
+	if updatedIssue == nil {
+		t.Fatal("Expected updatedIssue to be non-nil")
+	}
+
+	if updatedIssue.Fields.Summary != "New Map Summary" {
+		t.Errorf("Expected summary 'New Map Summary', got '%s'", updatedIssue.Fields.Summary)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+}
+
 func TestIssueService_AddComment(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
https://github.com/thought-machine/go-jira/pull/18 added the ability to return the issue for edits made directly to an issue object itself. However, there was no such support when editing an issue by its ID and supplying the map of edits. This diff provides this behaviour as a separate set of methods so as to provide backward compatibility with the existing `UpdateIssue`-based methods.